### PR TITLE
Add OS guess feature to scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ The tool concurrently discovers devices via ARP scanning and gathers rich inform
 - **Concurrent Scanning:**  
   Scans each /24 subnet concurrently to speed up device discovery.
   
-- **Rich Device Information:**  
-  Retrieves IP, MAC, vendor, device name, and optionally probes common open ports (e.g., 22, 23, 80, 443, 3389).
+- **Rich Device Information:**
+  Retrieves IP, MAC, vendor, device name, and optionally probes common open ports (e.g., 22, 23, 80, 443, 3389). The scanner can also guess the operating system of each device based on TTL values.
 
 - **Multiple Blocking Options:**  
   Choose from seven methods:
@@ -80,8 +80,8 @@ The tool concurrently discovers devices via ARP scanning and gathers rich inform
   - TCP SYN Flood (experimental)
   - DNS Amplification (experimental)
 
-- **User-Friendly GUI:**  
-  Built with Tkinter, the interface features a clear control layout.
+- **User-Friendly GUI:**
+  Built with Tkinter, the interface features a clear control layout. Columns for vendor, open ports, and OS guesses can be toggled on or off.
 
 ## Project Structure
 
@@ -110,7 +110,7 @@ project_root/
 
 1. **Using the GUI:**
    - Click **"Scan Network"** to start scanning.
-   - The table will display discovered devices along with IP, MAC, vendor, device name, and open ports.
+   - The table will display discovered devices along with IP, MAC, vendor, device name, guessed OS, and open ports.
    - To block a device, select it from the table, choose a blocking method from the dropdown (seven options available), and specify a duration.
    - Click **"Block Selected Device"** to initiate the blocking process.
 

--- a/network_scanner/gui.py
+++ b/network_scanner/gui.py
@@ -7,7 +7,7 @@ from .scanner import check_npcap, load_mac_prefixes, get_ip_range, scan_network,
 from .block import (block_via_arp_poison, block_via_arp_flood, block_via_arp_tornado,
                     block_via_mac_flood, block_via_icmp_unreachable, block_via_tcp_syn_flood,
                     block_via_dns_amplification)
-from .probe import probe_open_ports
+from .probe import probe_open_ports, guess_os
 from .utils import save_scan_results, FileViewer
 from .utils.log_saver import export_logs
 
@@ -24,9 +24,10 @@ class NetworkScannerApp:
         style = ttk.Style()
         style.theme_use("clam")
 
-        # Track whether we show vendor / ports columns
+        # Track whether we show vendor / ports / OS columns
         self.show_vendor_var = tk.BooleanVar(value=True)
         self.show_port_var = tk.BooleanVar(value=True)
+        self.show_os_var = tk.BooleanVar(value=True)
 
         # Data storage
         self.network = None
@@ -98,6 +99,11 @@ class NetworkScannerApp:
         options_menu.add_checkbutton(
             label="Open Ports Column",
             variable=self.show_port_var,
+            command=self.update_treeview_columns
+        )
+        options_menu.add_checkbutton(
+            label="OS Guess Column",
+            variable=self.show_os_var,
             command=self.update_treeview_columns
         )
         menubar.add_cascade(label="Options", menu=options_menu)
@@ -208,6 +214,8 @@ class NetworkScannerApp:
         if self.show_vendor_var.get():
             columns.append("Vendor")
         columns.append("Device Name")
+        if self.show_os_var.get():
+            columns.append("OS Guess")
         if self.show_port_var.get():
             columns.append("Open Ports")
 
@@ -224,6 +232,8 @@ class NetworkScannerApp:
                 self.tree.column(col, anchor="center", stretch=True, width=140, minwidth=100)
             elif col == "Device Name":
                 self.tree.column(col, anchor="center", stretch=True, width=140, minwidth=100)
+            elif col == "OS Guess":
+                self.tree.column(col, anchor="center", stretch=True, width=100, minwidth=80)
             elif col == "Open Ports":
                 self.tree.column(col, anchor="center", stretch=True, width=130, minwidth=100)
 
@@ -242,6 +252,8 @@ class NetworkScannerApp:
         if self.show_vendor_var.get():
             row.append(device.get("vendor", "Not Fetched"))
         row.append(device.get("device_name", "Unknown"))
+        if self.show_os_var.get():
+            row.append(device.get("os_guess", "Unknown"))
         if self.show_port_var.get():
             ports = device.get("open_ports", [])
             row.append(",".join(map(str, ports)) if ports else "None")
@@ -277,13 +289,26 @@ class NetworkScannerApp:
             for device in devices:
                 device["vendor"] = "Not Fetched"
                 device["open_ports"] = []
+                device["os_guess"] = "Unknown"
 
             # Step 5: Get vendor info if enabled.
             if self.show_vendor_var.get():
                 for device in devices:
                     device["vendor"] = get_mac_vendor(device.get("mac", ""), self.mac_prefixes)
 
-            # Step 6: Scan open ports if enabled.
+            # Step 6: Get OS guess if enabled.
+            if self.show_os_var.get():
+                with ThreadPoolExecutor(max_workers=10) as executor:
+                    future_to_device = {
+                        executor.submit(guess_os, device["ip"]): device for device in devices
+                    }
+                    for future in as_completed(future_to_device):
+                        dev = future_to_device[future]
+                        try:
+                            dev["os_guess"] = future.result()
+                        except Exception:
+                            dev["os_guess"] = "Unknown"
+            # Step 7: Scan open ports if enabled.
             if self.show_port_var.get():
                 with ThreadPoolExecutor(max_workers=10) as executor:
                     future_to_device = {

--- a/network_scanner/probe.py
+++ b/network_scanner/probe.py
@@ -1,4 +1,23 @@
 import socket
+from scapy.all import IP, ICMP, sr1
+
+
+def guess_os(ip, timeout=1):
+    """Return a simple OS guess based on the target's TTL value."""
+    try:
+        pkt = IP(dst=ip) / ICMP()
+        resp = sr1(pkt, timeout=timeout, verbose=False)
+        if resp:
+            ttl = int(resp.ttl)
+            if ttl <= 64:
+                return "Linux/Unix"
+            if ttl <= 128:
+                return "Windows"
+            if ttl <= 254:
+                return "Solaris/AIX"
+    except Exception:
+        pass
+    return "Unknown"
 
 def probe_open_ports(ip, ports=[22, 23, 80, 443, 3389], timeout=0.5):
     open_ports = []


### PR DESCRIPTION
## Summary
- extend `probe` module with `guess_os` helper using scapy
- allow toggling an **OS Guess** column in the GUI
- fetch OS guess during scans and show it in results
- update README to document new functionality

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f4a91953c8328904e47ce7cce9f4e