### PR TITLE
Fix log export path

### DIFF
--- a/network_scanner/utils/log_saver.py
+++ b/network_scanner/utils/log_saver.py
@@ -15,8 +15,11 @@ def export_logs(parent_window=None):
         bool: True if export was successful, False otherwise
     """
     try:
-        # Get the current log file path
-        log_file = 'scanner.log'
+        # Get the current log file path from the CommonLogger instance
+        # so we export the same log file that is being written by the
+        # application. This ensures consistency with CommonLogger._log_file
+        # ("hello-ips.log").
+        log_file = getattr(logger, "_log_file", "hello-ips.log")
         if not os.path.exists(log_file):
             if parent_window:
                 messagebox.showwarning("No Logs", "No log file found to export.")


### PR DESCRIPTION
## Summary
- reference CommonLogger's log file in `export_logs`

## Testing
- `python -m py_compile network_scanner/utils/log_saver.py`


------
https://chatgpt.com/codex/tasks/task_e_685f91469a8483288a0c8fc0d52326a1