### PR TITLE
Fix exported log file name

### DIFF
--- a/network_scanner/utils/log_saver.py
+++ b/network_scanner/utils/log_saver.py
@@ -15,11 +15,10 @@ def export_logs(parent_window=None):
         bool: True if export was successful, False otherwise
     """
     try:
-        # Get the current log file path from the CommonLogger instance
-        # so we export the same log file that is being written by the
-        # application. This ensures consistency with CommonLogger._log_file
-        # ("hello-ips.log").
-        log_file = getattr(logger, "_log_file", "hello-ips.log")
+        # Export the same log file that CommonLogger writes to.
+        # CommonLogger._log_file defaults to "hello-ips.log", so we use
+        # that constant here to avoid mismatches.
+        log_file = "hello-ips.log"
         if not os.path.exists(log_file):
             if parent_window:
                 messagebox.showwarning("No Logs", "No log file found to export.")


### PR DESCRIPTION
## Summary
- export logs to the same file name as CommonLogger (`hello-ips.log`)

## Testing
- `python -m py_compile network_scanner/utils/log_saver.py network_scanner/utils/logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68608dae59848328be5ed283bc5d0d73