### PR TITLE
Add retry and timeout controls for network scanning

### DIFF
--- a/network_scanner/gui.py
+++ b/network_scanner/gui.py
@@ -130,17 +130,20 @@ class NetworkScannerApp:
         self.save_button = ttk.Button(parent, text="Save Results", command=self.save_results)
         self.save_button.grid(row=0, column=1, padx=5, pady=5)
 
-        ttk.Label(parent, text="Retries:").grid(row=0, column=2, padx=(10, 2), pady=5)
+        options = ttk.Frame(parent)
+        options.grid(row=1, column=0, columnspan=2, sticky="w", pady=(0, 5))
+
+        ttk.Label(options, text="Retries:").grid(row=0, column=0, padx=(5, 2))
         self.retry_var = tk.IntVar(value=2)
-        self.retry_entry = ttk.Entry(parent, textvariable=self.retry_var, width=5)
-        self.retry_entry.grid(row=0, column=3, padx=(0, 5), pady=5)
+        self.retry_entry = ttk.Entry(options, textvariable=self.retry_var, width=5)
+        self.retry_entry.grid(row=0, column=1, padx=(0, 10))
 
-        ttk.Label(parent, text="Timeout(s):").grid(row=0, column=4, padx=(10, 2), pady=5)
+        ttk.Label(options, text="Timeout(s):").grid(row=0, column=2, padx=(5, 2))
         self.timeout_var = tk.DoubleVar(value=5)
-        self.timeout_entry = ttk.Entry(parent, textvariable=self.timeout_var, width=5)
-        self.timeout_entry.grid(row=0, column=5, padx=(0, 5), pady=5)
+        self.timeout_entry = ttk.Entry(options, textvariable=self.timeout_var, width=5)
+        self.timeout_entry.grid(row=0, column=3, padx=(0, 5))
 
-        parent.columnconfigure(6, weight=1)
+        parent.columnconfigure(1, weight=1)
 
     def create_treeview(self, parent):
         # Container for the treeview + scrollbar

--- a/network_scanner/gui.py
+++ b/network_scanner/gui.py
@@ -130,7 +130,17 @@ class NetworkScannerApp:
         self.save_button = ttk.Button(parent, text="Save Results", command=self.save_results)
         self.save_button.grid(row=0, column=1, padx=5, pady=5)
 
-        parent.columnconfigure(2, weight=1)
+        ttk.Label(parent, text="Retries:").grid(row=0, column=2, padx=(10, 2), pady=5)
+        self.retry_var = tk.IntVar(value=2)
+        self.retry_entry = ttk.Entry(parent, textvariable=self.retry_var, width=5)
+        self.retry_entry.grid(row=0, column=3, padx=(0, 5), pady=5)
+
+        ttk.Label(parent, text="Timeout(s):").grid(row=0, column=4, padx=(10, 2), pady=5)
+        self.timeout_var = tk.DoubleVar(value=5)
+        self.timeout_entry = ttk.Entry(parent, textvariable=self.timeout_var, width=5)
+        self.timeout_entry.grid(row=0, column=5, padx=(0, 5), pady=5)
+
+        parent.columnconfigure(6, weight=1)
 
     def create_treeview(self, parent):
         # Container for the treeview + scrollbar
@@ -284,7 +294,19 @@ class NetworkScannerApp:
             self.network = ip_range
 
             # Step 4: Scan the network asynchronously.
-            devices = asyncio.run(scan_network(ip_range, self.mac_prefixes))
+            retry = max(1, self.retry_var.get())
+            try:
+                timeout = float(self.timeout_var.get())
+            except Exception:
+                timeout = 5
+            devices = asyncio.run(
+                scan_network(
+                    ip_range,
+                    self.mac_prefixes,
+                    timeout=timeout,
+                    retry=retry,
+                )
+            )
 
             # Initialize vendor and port info.
             for device in devices:

--- a/network_scanner/scanner.py
+++ b/network_scanner/scanner.py
@@ -163,7 +163,7 @@ def get_ip_range():
         logger.error(f"Failed to determine local IP range: {e}")
         raise
 
-async def scan_subnet(subnet, mac_prefixes, timeout=3, retry=2):
+async def scan_subnet(subnet, mac_prefixes, timeout=5, retry=2):
     """Asynchronously scan a subnet for active devices."""
     results = []
 
@@ -178,7 +178,9 @@ async def scan_subnet(subnet, mac_prefixes, timeout=3, retry=2):
         # Use AsyncSniffer without a timeout so we control when to stop it.
         sniffer = AsyncSniffer(filter="arp and arp[6:2] == 2")
         sniffer.start()
-        await asyncio.to_thread(sendp, packet, verbose=False)
+        for _ in range(max(1, retry)):
+            await asyncio.to_thread(sendp, packet, verbose=False)
+            await asyncio.sleep(0.5)
         await asyncio.sleep(timeout)
         # sniffer.stop() returns the captured packets.
         answered = sniffer.stop()
@@ -198,7 +200,14 @@ async def scan_subnet(subnet, mac_prefixes, timeout=3, retry=2):
             results.append(device)
     return results
 
-async def scan_network(ip_range, mac_prefixes, max_workers=10, subnet_prefix=24):
+async def scan_network(
+    ip_range,
+    mac_prefixes,
+    max_workers=10,
+    subnet_prefix=24,
+    timeout=5,
+    retry=2,
+):
     """Asynchronously scan a network by scanning subnets concurrently."""
     devices = []
     try:
@@ -211,7 +220,7 @@ async def scan_network(ip_range, mac_prefixes, max_workers=10, subnet_prefix=24)
 
         async def worker(subnet):
             async with semaphore:
-                return await scan_subnet(subnet, mac_prefixes)
+                return await scan_subnet(subnet, mac_prefixes, timeout=timeout, retry=retry)
 
         tasks = [asyncio.create_task(worker(subnet)) for subnet in subnets]
         results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/network_scanner/scanner.py
+++ b/network_scanner/scanner.py
@@ -164,8 +164,12 @@ def get_ip_range():
         raise
 
 async def scan_subnet(subnet, mac_prefixes, timeout=5, retry=2):
-    """Asynchronously scan a subnet for active devices."""
-    results = []
+    """Asynchronously scan a subnet for active devices.
+
+    ``retry`` determines how many times the ARP request is resent. ``timeout``
+    specifies the time to wait for responses.
+    """
+    results = {}
 
     if not check_npcap():
         logger.warning("NPCAP not available, scanning may be limited")
@@ -184,21 +188,22 @@ async def scan_subnet(subnet, mac_prefixes, timeout=5, retry=2):
         await asyncio.sleep(timeout)
         # sniffer.stop() returns the captured packets.
         answered = sniffer.stop()
-        logger.info(f"Found {len(answered)} devices in subnet {subnet}")
+        logger.info(f"Found {len(answered)} responses in subnet {subnet}")
     except Exception as e:
         logger.error(f"Error scanning subnet {subnet}: {e}")
-        return results
+        return list(results.values())
 
     for pkt in answered:
         if ARP in pkt and pkt[ARP].op == 2:
-            device = {
-                'ip': pkt[ARP].psrc,
-                'mac': pkt[ARP].hwsrc,
-                'vendor': get_mac_vendor(pkt[ARP].hwsrc, mac_prefixes),
-                'device_name': get_device_name(pkt[ARP].psrc)
-            }
-            results.append(device)
-    return results
+            ip = pkt[ARP].psrc
+            if ip not in results:
+                results[ip] = {
+                    "ip": ip,
+                    "mac": pkt[ARP].hwsrc,
+                    "vendor": get_mac_vendor(pkt[ARP].hwsrc, mac_prefixes),
+                    "device_name": get_device_name(ip),
+                }
+    return list(results.values())
 
 async def scan_network(
     ip_range,
@@ -209,7 +214,7 @@ async def scan_network(
     retry=2,
 ):
     """Asynchronously scan a network by scanning subnets concurrently."""
-    devices = []
+    devices = {}
     try:
         subnets = list(ip_range.subnets(new_prefix=subnet_prefix))
         logger.info(
@@ -229,10 +234,11 @@ async def scan_network(
             if isinstance(result, Exception):
                 logger.error(f"Error processing subnet: {result}")
             else:
-                devices.extend(result)
+                for dev in result:
+                    devices.setdefault(dev["ip"], dev)
 
-        logger.info(f"Scan completed. Found {len(devices)} devices")
+        logger.info(f"Scan completed. Found {len(devices)} unique devices")
     except Exception as e:
         logger.error(f"Network scan failed: {e}")
 
-    return devices
+    return list(devices.values())


### PR DESCRIPTION
## Summary
- let `scan_subnet` resend ARP packets multiple times
- support `timeout` and `retry` options in `scan_network`
- expose retry/timeout settings in the GUI

## Testing
- `python -m py_compile network_scanner/scanner.py network_scanner/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68612e0526ec8328bc788e38fef3a01c